### PR TITLE
ET-49 Update docs with signature timestamp parameters

### DIFF
--- a/doc/docs/keys.md
+++ b/doc/docs/keys.md
@@ -31,7 +31,7 @@
 
 `{alias}` example value : `certificate`
 
-<b>GET</b> @ <i>/services/rest/server-signing/keys/{alias}</i>
+<b>GET</b> @ <i>/services/rest/server-signing/key/{alias}</i>
 
 ### Response body
 

--- a/doc/docs/signing.md
+++ b/doc/docs/signing.md
@@ -8,7 +8,7 @@ Signing a PDF requires to execute the 3 following API Calls.
 
 <b>POST</b> @ <i>/services/rest/signature/one-document/getDataToSign</i>
 
-### Request Body
+### Request Body without timestamp
 
 - `signingCertificate.encodedCertificate` :  Embed the signing certificate 
 and its chain to the signature document.
@@ -24,6 +24,41 @@ This should match one of the key entries from [keys](keys.md)
 	"encryptionAlgorithm" : "RSA",
     "digestAlgorithm" : "SHA256"
     ,
+    "signingCertificate" : {
+      "encodedCertificate" : "MIIC6j...."
+    }
+  },
+  "toSignDocument" : {
+    "bytes" : "JVBERi0xLjM...",
+    "name" : "important.pdf"
+  }
+}
+```
+
+### Request Body with timestamp
+
+<b><i>In case we also need to provide a timestamp within the signature, we need to 
+provide the  following extra parameters.</i></b>
+
+- `signatureLevel` becomes `PAdES_BASELINE_T`
+-  we need the extra JSON objects of `contentTimestampParameters` and `signatureTimestampParameters`.
+
+```json
+{
+  "parameters" : {
+    "signatureLevel" : "PAdES_BASELINE_T",
+    "signaturePackaging" : "ENVELOPED",
+    "signatureAlgorithm" : "RSA_SHA256",
+	"encryptionAlgorithm" : "RSA",
+    "digestAlgorithm" : "SHA256",
+    "contentTimestampParameters" : {
+      "digestAlgorithm" : "SHA256",
+      "canonicalizationMethod" : "http://www.w3.org/2001/10/xml-exc-c14n#"
+    },
+    "signatureTimestampParameters" : {
+      "digestAlgorithm" : "SHA256",
+      "canonicalizationMethod" : "http://www.w3.org/2001/10/xml-exc-c14n#"
+    },
     "signingCertificate" : {
       "encodedCertificate" : "MIIC6j...."
     }
@@ -77,7 +112,7 @@ The response contains the digest that will later be signed.
 
 ## POST - Sign the Document
 
-### Request
+### Request Body without timestamp
 
 <b>POST</b> @ <i>/services/rest/signature/one-document/signDocument</i>
 
@@ -99,6 +134,45 @@ This should match one of the key entries from [keys](keys.md)
     "signatureAlgorithm" : "RSA_SHA256",
     "digestAlgorithm" : "SHA256",
     "encryptionAlgorithm" : "RSA"
+  },
+  "signatureValue" : {
+    "algorithm" : "RSA_SHA256",
+    "value" : "IWbu5..."
+  },
+  "toSignDocument" : {
+    "bytes" : "JVBER....",
+    "name" : "important.pdf"
+  }
+}
+```
+
+### Request Body with timestamp
+
+<b><i>In case we also need to provide a timestamp within the signature, we need to 
+provide the  following extra parameters.</i></b>
+
+- `signatureLevel` becomes `PAdES_BASELINE_T`
+-  we need the extra JSON objects of `contentTimestampParameters` and `signatureTimestampParameters`.
+
+```json
+{
+  "parameters" : {
+    "signingCertificate" : {
+      "encodedCertificate" : "MIIC6..."
+    },
+    "signatureLevel" : "PAdES_BASELINE_T",
+    "signaturePackaging" : "ENVELOPED",
+    "signatureAlgorithm" : "RSA_SHA256",
+    "digestAlgorithm" : "SHA256",
+    "encryptionAlgorithm" : "RSA",
+    "contentTimestampParameters" : {
+      "digestAlgorithm" : "SHA256",
+      "canonicalizationMethod" : "http://www.w3.org/2001/10/xml-exc-c14n#"
+    },
+    "signatureTimestampParameters" : {
+      "digestAlgorithm" : "SHA256",
+      "canonicalizationMethod" : "http://www.w3.org/2001/10/xml-exc-c14n#"
+    }
   },
   "signatureValue" : {
     "algorithm" : "RSA_SHA256",


### PR DESCRIPTION
- Fix minor type in keys api call
- Add timestamp parameters sections in the docs for signatures that also need to be timestamped